### PR TITLE
Update to use `node16` instead of `node12`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: "Will not fail the step if anything fails"
     default: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
According to this [GitHub blogpost](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) it was needed to update it in order to fix the issue: #74