### PR TITLE
Add write permission to GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ jobs:
     - name: All things angular
       uses: AhsanAyaz/angular-deploy-gh-pages-actions@[version] ## replace by latest version without it you will see Expected format {org}/{repo}[/path]@ref. Actual 'AhsanAyaz/angular-deploy-gh-pages-actions',Input string was not in a correct format.
       with:
-        github_access_token: ${{ secrets.ACCESS_TOKEN }} # see the Configuration section for how you can create secrets
+        github_access_token: ${{ secrets.GITHUB_TOKEN }} # see the Configuration section for how you can create secrets
         build_configuration: staging # The build environment for the app. please look configurations in your angular.json
         base_href: /my-project/   # make sure this corresponds to https://<your_username>.github.io/<base_href>/
         deploy_branch: gh-pages # The branch the action should deploy to.
         angular_dist_build_folder: dist/my-project # The folder where your project is supposed to be after running ng build by the action.
+
+permissions:
+  contents: write # Allow write permission to GITHUB_TOKEN to commit to deploy branch.
 ```
 
 If you'd like to make it so the workflow only triggers on push events to specific branches then you can modify the `on` section.


### PR DESCRIPTION
Update documentation, fixes issue in #61.

GitHub changed new repository default settings and made [workflow permissions read-only by default](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/).

(From https://github.com/JamesIves/github-pages-deploy-action/issues/1285#issuecomment-1383004519.)